### PR TITLE
Fikser oppkobling for redisClient mot redisServer i test.

### DIFF
--- a/src/main/kotlin/no/nav/omsorgspengerutbetaling/redis/RedisConfig.kt
+++ b/src/main/kotlin/no/nav/omsorgspengerutbetaling/redis/RedisConfig.kt
@@ -2,12 +2,21 @@ package no.nav.omsorgspengerutbetaling.redis
 
 import io.ktor.util.KtorExperimentalAPI
 import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisURI
+import java.time.Duration
 
 internal object RedisConfig {
 
     @KtorExperimentalAPI
     internal fun redisClient(redisHost: String, redisPort: Int): RedisClient {
-        return RedisClient.create("redis://${redisHost}:${redisPort}")
+        val host = redisHost.resolveHost()
+        return RedisClient.create(RedisURI(host, redisPort, Duration.ofSeconds(60)))
     }
 
+    private fun String.resolveHost() = when {
+        nonRoutableMetaAddress() -> replace("0.0.0.0", "localhost")
+        else -> this
+    }
+
+    private fun String.nonRoutableMetaAddress(): Boolean = contains("0.0.0.0")
 }

--- a/src/main/kotlin/no/nav/omsorgspengerutbetaling/redis/RedisConfig.kt
+++ b/src/main/kotlin/no/nav/omsorgspengerutbetaling/redis/RedisConfig.kt
@@ -9,14 +9,6 @@ internal object RedisConfig {
 
     @KtorExperimentalAPI
     internal fun redisClient(redisHost: String, redisPort: Int): RedisClient {
-        val host = redisHost.resolveHost()
-        return RedisClient.create(RedisURI(host, redisPort, Duration.ofSeconds(60)))
+        return RedisClient.create(RedisURI(redisHost, redisPort, Duration.ofSeconds(60)))
     }
-
-    private fun String.resolveHost() = when {
-        nonRoutableMetaAddress() -> replace("0.0.0.0", "localhost")
-        else -> this
-    }
-
-    private fun String.nonRoutableMetaAddress(): Boolean = contains("0.0.0.0")
 }

--- a/src/test/kotlin/no/nav/omsorgspengerutbetaling/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspengerutbetaling/ApplicationTest.kt
@@ -63,7 +63,7 @@ class ApplicationTest {
             .stubK9OppslagBarn()
 
         val redisServer: RedisServer = RedisServer
-            .newRedisServer(6379)
+            .newRedisServer()
             .started()
 
         fun getConfig(): ApplicationConfig {

--- a/src/test/kotlin/no/nav/omsorgspengerutbetaling/ApplicationWithMocks.kt
+++ b/src/test/kotlin/no/nav/omsorgspengerutbetaling/ApplicationWithMocks.kt
@@ -32,7 +32,7 @@ class ApplicationWithMocks {
                 .stubK9OppslagSoker()
 
             val redisServer: RedisServer = RedisServer
-                .newRedisServer(6379)
+                .newRedisServer()
                 .started()
 
             val testArgs = TestConfiguration.asMap(

--- a/src/test/kotlin/no/nav/omsorgspengerutbetaling/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/omsorgspengerutbetaling/TestConfiguration.kt
@@ -50,7 +50,7 @@ object TestConfiguration {
             map["nav.auth.issuers.1.audience"] = LoginService.V1_0.getAudience()
         }
 
-        map["nav.redis.host"] = redisServer.host
+        map["nav.redis.host"] = "localhost"
         map["nav.redis.port"] = "${redisServer.bindPort}"
         map["nav.storage.passphrase"] = "verySecret"
 

--- a/src/test/kotlin/no/nav/omsorgspengerutbetaling/mellomlagring/MellomlagringTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspengerutbetaling/mellomlagring/MellomlagringTest.kt
@@ -23,7 +23,7 @@ class MellomlagringTest {
         val logger = LoggerFactory.getLogger(MellomlagringTest::class.java)
 
         val redisServer: RedisServer = RedisServer
-            .newRedisServer(6379)
+            .newRedisServer()
             .started()
 
         val redisClient = RedisConfig.redisClient(

--- a/src/test/kotlin/no/nav/omsorgspengerutbetaling/mellomlagring/MellomlagringTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspengerutbetaling/mellomlagring/MellomlagringTest.kt
@@ -27,7 +27,7 @@ class MellomlagringTest {
             .started()
 
         val redisClient = RedisConfig.redisClient(
-            redisHost = redisServer.host,
+            redisHost = "localhost",
             redisPort = redisServer.bindPort
         )
 


### PR DESCRIPTION
Når redisClient prøver å koble på redisServer i Github Actions opplever man tilkoblingsproblemer.

Da RedisServer starter med følgende host adresse: 0.0.0.0, og denne sendes videre til redis klienten, prøver den da å koble seg opp mot 0.0.0.0:6379. 

Teorien var da at det kan være annen server i gh actions som også lytter på 0.0.0.0:6379, som blir truffet av oppkoblingen istedenfor redis serveren.

- Erstatter da 0.0.0.0 med localhost ved instansiering av redis klienten i test.
- Erstatter også redisserver til å kjøre på en random port.